### PR TITLE
IDカラムの仕様の変更

### DIFF
--- a/mitama/db/model.py
+++ b/mitama/db/model.py
@@ -9,6 +9,7 @@
 """
 
 import re
+import uuid
 
 from sqlalchemy.ext.declarative import declarative_base, declared_attr
 from sqlalchemy.orm import ColumnProperty, class_mapper
@@ -18,9 +19,16 @@ from mitama._extra import _classproperty
 
 from .types import Column, Group, Integer, LargeBinary, Node, String
 
+def UUID(prefix = None):
+    def genUUID():
+        s = str(uuid.uuid4())
+        if prefix is not None:
+            s = prefix + "-" + s
+        return s
+    return genUUID
 
 class Model:
-    _id = Column(Integer, primary_key=True)
+    _id = Column(String, default=UUID(), primary_key=True, nullable=False)
 
     @classmethod
     def attribute_names(cls):

--- a/mitama/db/types.py
+++ b/mitama/db/types.py
@@ -18,8 +18,10 @@ class User(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value == None:
             return None
-        else:
+        elif value.__class__.__name__ == "User":
             return value._id
+        else:
+            return value
 
     def process_result_value(self, value, dialect):
         from mitama.models import User
@@ -37,8 +39,10 @@ class Group(TypeDecorator):
     def process_bind_param(self, value, dialect):
         if value == None:
             return None
-        else:
+        elif value.__class__.__name__ == "Group":
             return value._id
+        else:
+            return value
 
     def process_result_value(self, value, dialect):
         from mitama.models import Group

--- a/mitama/db/types.py
+++ b/mitama/db/types.py
@@ -54,20 +54,23 @@ class Node(TypeDecorator):
     impl = Integer
 
     def process_bind_param(self, value, dialect):
-        if value.__class__.__name__ == "Group":
-            return value._id * 2
-        elif value.__class__.__name__ == "User":
-            return value._id * 2 - 1
+        if value.__class__.__name__ == "Group" or value.__class__.__name__ == "User":
+            return value._id
+        elif type(value) == str and value.split("-")[0] in ["user", "group"]:
+            return value
         else:
             raise TypeError("Appending object must be Group or User instance")
 
     def process_result_value(self, value, dialect):
-        if value % 2 == 1:
+        prefix = value.split("-")[0]
+        if prefix == "user":
             from mitama.models import User
 
-            node = User.retrieve((value + 1) / 2)
-        else:
+            node = User.retrieve(value)
+        elif prefix == "group":
             from mitama.models import Group
 
-            node = Group.retrieve(value / 2)
+            node = Group.retrieve(value)
+        else:
+            raise TypeError("Invalid ID format")
         return node

--- a/mitama/models/__init__.py
+++ b/mitama/models/__init__.py
@@ -25,6 +25,7 @@ from mitama.db import _CoreDatabase, func, orm
 from mitama.db.types import Column, Group, Integer, LargeBinary
 from mitama.db.types import Node as NodeType
 from mitama.db.types import String
+from mitama.db.model import UUID
 from mitama.noimage import load_noimage_group, load_noimage_user
 from mitama.conf import get_from_project_dir
 
@@ -169,6 +170,7 @@ class User(Node, db.Model):
     """
 
     __tablename__ = "mitama_user"
+    _id = Column(String, default=UUID("user"), primary_key = True, nullable=False)
     password = Column(String(255))
 
     def to_dict(self, only_profile=False):
@@ -274,6 +276,7 @@ class Group(Node, db.Model):
     """
 
     __tablename__ = "mitama_group"
+    _id = Column(String, default=UUID("group"), primary_key=True, nullable=False)
 
     def to_dict(self, only_profile=False):
         profile = super().to_dict()

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,43 @@
+import unittest
+
+from mitama.db import _CoreDatabase, BaseDatabase
+
+db = _CoreDatabase.test()
+
+from mitama.models import Group, User
+from mitama.db.types import Column, Node
+
+db_ = BaseDatabase.test()
+
+class ModelC(db_.Model):
+    node = Column(Node)
+
+db_.create_all()
+
+class TestNode(unittest.TestCase):
+    def test_node(self):
+        group = Group()
+        group.name = "team1"
+        group.screen_name = "team1"
+        user1 = User()
+        user1.name = "bob"
+        user1.screen_name = "bob"
+        group.create()
+        user1.create()
+        hoge = ModelC()
+        hoge.node = group
+        hoge.create()
+        piyo = ModelC()
+        piyo.node = user1
+        piyo.create()
+        foo = ModelC()
+        foo.node = group._id
+        foo.create()
+        bar= ModelC()
+        bar.node = user1._id
+        bar.create()
+        self.assertEqual(hoge.node, group)
+        self.assertEqual(piyo.node, user1)
+        self.assertEqual(foo.node, group)
+        self.assertEqual(bar.node, user1)
+        pass


### PR DESCRIPTION
## 概要 <!-- 変更機能とIssue番号 -->
IDカラムの仕様を変更

## 変更内容 <!-- なにをどう変更したかなど、レビュワーにわかるように、技術的視線での変更概要説明 -->
- 今までIDには連番のIntegerを採用していたところを、UUIDに変更
- UserとGroupに関しては、それぞれ「user-」「group-」という接頭辞をつける。
- データベースのNode型においては、接頭辞によってUserかGroupかを判別する
- Node型への代入時にはインスタンスでなくても良いようにした。

## 影響範囲
アプリの動作部分全体に影響を与えるため、メジャーバージョンの変更が必要。

## 動作手順 <!-- 手順や動作確認用のURLなど(必要あれば) -->
一応unittestを書いておいたので、
```
$ python -m unittest tests/
```
で確認できます。